### PR TITLE
Fix compilation on !x86 archs

### DIFF
--- a/qqconf/src/jointlevel_fft_twosided.cpp
+++ b/qqconf/src/jointlevel_fft_twosided.cpp
@@ -8,7 +8,14 @@
 #include <algorithm>
 #include <iostream>
 #include <fftw3.h>
-#include "mm_malloc.h"
+
+#if !defined(__SSE__)
+  #include <stdlib.h>
+  #define _mm_malloc(size, align) aligned_alloc(align, size)
+  #define _mm_free free
+#else
+  #include <mm_malloc.h>
+#endif
 using namespace Rcpp;
 
 #define ALIGNMENT (32)


### PR DESCRIPTION
We discovered this in the debian package. This PR is an attempt to fix the same. More details [here](https://lists.debian.org/debian-r/2022/03/msg00005.html)